### PR TITLE
:hammer: #66 #57 Nav feat, Auth, Login feat

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { BrowserRouter, Route, Router, Routes } from "react-router-dom";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
 import { Provider } from "react-redux";
 import { globalStyles } from "./theme/theme";
 import { Home } from "./view/viewHome";
@@ -8,6 +8,7 @@ import { Chat } from "./view/viewChat";
 import { Profile } from "./view/viewProfile";
 import { Watch } from "./view/viewWatch";
 import { Login } from "./view/viewLogin";
+import { RootControl } from "./component/rootControl";
 import store from "./redux/store";
 
 function App() {
@@ -16,14 +17,14 @@ function App() {
     <Provider store={store}>
       <BrowserRouter>
         <Routes>
-          <Route path="/" element={<Login />} />
+          <Route path="/login" element={<Login />} />
           <Route path="/Home" element={<Home />} />
           <Route path="/game" element={<Game />} />
           <Route path="/watch" element={<Watch />} />
           <Route path="/profile/" element={<Profile />} />
           <Route path="/profile/:userId" element={<Profile />} />
           <Route path="/chat" element={<Chat />} />
-          <Route path="/*" element={<Login />} />
+          <Route path="/*" element={<RootControl />} />
         </Routes>
       </BrowserRouter>
     </Provider>

--- a/src/component/nav/navAlam.tsx
+++ b/src/component/nav/navAlam.tsx
@@ -1,12 +1,10 @@
 import React from "react";
 import { styled } from "@stitches/react";
+import { useSelector } from "react-redux";
 import * as theme from "../../theme/theme";
-import { BORDER_BASIC } from "../../theme/theme";
-
-interface myProfile {
-  name: string;
-  status: string;
-}
+import { ReqLoggedUserDate } from "../../feat/nav/request";
+import { ReducerType } from "../../redux/rootReducer";
+import { LoggedUserData } from "../../redux/slices/loggedUser";
 
 const ProfileTextName = styled("div", {
   width: "100%",
@@ -61,24 +59,38 @@ const NavAlarm = styled("div", {
   display: "flex"
 });
 
-export function ComponentNavAlam({ name, status }:myProfile) {
-  // const { myName }:myProfile = name;
-  // const { myStatus } = status;
-  const link:string = "/asset/profileImage/skim.png";
+export function ComponentNavAlam() {
+  const loggedUser = useSelector<ReducerType, LoggedUserData>((state) => state.loggedUser);
 
-  // console.log(myName);
+  ReqLoggedUserDate();
+
+  const StatusDisplayDistributor = () => {
+    switch (loggedUser.status) {
+      case "USST10":
+        return "online";
+      case "USST20":
+        return "offline";
+      case "USST30":
+        return "in game";
+      case "USST40":
+        return "sleeping";
+      default:
+        break;
+    }
+    return "statue error";
+  };
 
   return (
     <NavAlarm>
       <NavAlarmProfileImg className="navAlarm">
-        <ProfileImage className="profileimg" src={link} />
+        <ProfileImage className="profileimg" src={loggedUser.img} />
       </NavAlarmProfileImg>
       <NavAlarmProfileText>
         <ProfileTextName className="profiletext">
-          {name}
+          {loggedUser.nick}
         </ProfileTextName>
         <ProfileTextStatus className="profilestatus">
-          {status}
+          {StatusDisplayDistributor()}
         </ProfileTextStatus>
       </NavAlarmProfileText>
       <NavAlarmAlarm />

--- a/src/component/rootControl.tsx
+++ b/src/component/rootControl.tsx
@@ -1,0 +1,33 @@
+import axios from "axios";
+import React, { useEffect } from "react";
+import { useSelector } from "react-redux";
+import { Navigate } from "react-router-dom";
+import store from "../redux/store";
+import { ReducerType } from "../redux/rootReducer";
+import { AuthData, setAuth } from "../redux/slices/auth";
+
+export function RootControl() {
+  const auth = useSelector<ReducerType, AuthData>((state) => state.auth);
+
+  axios.defaults.withCredentials = true;
+  // 요청 url 변경 필요.
+  axios.get("https://bongcheonmountainclub.iptime.org/api/users/profile").then((response) => {
+    if (response.status === 200) {
+      useEffect(() => {
+        store.dispatch(setAuth({ auth: true } as AuthData));
+      }, []);
+    }
+  });
+
+  if (auth.auth) {
+    if (auth.isRequire2f) {
+      if (auth.auth2f) {
+        return (<Navigate replace to="/home" />);
+      }
+      return (<Navigate replace to="/login" />); // Fix require to 2f login page.
+    }
+    return (<Navigate replace to="/home" />);
+  }
+
+  return (<Navigate replace to="/login" />);
+}

--- a/src/container/contentLogin.tsx
+++ b/src/container/contentLogin.tsx
@@ -192,7 +192,7 @@ const ButtonLogin2 = theme.styled(ButtonLogin, {
 
 export function ContainerContents() {
   const logIn = () => {
-    window.location.href = "/api/auth/42";
+    window.location.href = "/api/auth/login";
   };
   return (
     <LoginSpace>

--- a/src/container/navCommunity.tsx
+++ b/src/container/navCommunity.tsx
@@ -1,13 +1,10 @@
-import React, { Reducer, useState } from "react";
+import React from "react";
 import { styled } from "@stitches/react";
-import { useSelector } from "react-redux";
 import * as theme from "../theme/theme";
 import { ComponentNavAlam } from "../component/nav/navAlam";
 import { ComponentNavSearch } from "../component/nav/navSearch";
 import { ComponentNavFriendZone } from "../component/nav/navFriendZone";
 import { ComponentNavInviteZone } from "../component/nav/navInviteZone";
-import { ReducerType } from "../redux/rootReducer";
-import { LoggedUserData } from "../redux/slices/loggedUser";
 
 // navCommunity에서 사용할 status 정의
 //  (+ 현재 status는 socket으로 처리)
@@ -22,20 +19,18 @@ import { LoggedUserData } from "../redux/slices/loggedUser";
 //    nickname: ""
 // }
 
-export function ContainerNavCommunity() {
-  const loggedUser = useSelector<ReducerType, LoggedUserData>((state) => state.loggedUser);
+const NavCommunity = styled(theme.NeonHoverRed, {
+  height: "90%",
+  maxHeight: "calc(100% - 100px)",
+});
 
+export function ContainerNavCommunity() {
   return (
     <NavCommunity className="navCommunity">
-      <ComponentNavAlam name={loggedUser.nick} status="sleeping" />
+      <ComponentNavAlam />
       <ComponentNavSearch />
       <ComponentNavFriendZone />
       <ComponentNavInviteZone />
     </NavCommunity>
   );
 }
-
-const NavCommunity = styled(theme.NeonHoverRed, {
-  height: "90%",
-  maxHeight: "calc(100% - 100px)",
-});

--- a/src/feat/nav/request.ts
+++ b/src/feat/nav/request.ts
@@ -1,0 +1,28 @@
+import { useEffect } from "react";
+import axios from "axios";
+import store from "../../redux/store";
+import { LoggedUserData, setLoggedUser } from "../../redux/slices/loggedUser";
+import { AuthData, setAuth } from "../../redux/slices/auth";
+
+function ReqLoggedUserDate() {
+  useEffect(() => {
+    axios.defaults.withCredentials = true;
+    axios.get("https://bongcheonmountainclub.iptime.org/api/users/profile").then((response) => {
+      if (response.status === 200) {
+        const recvData = Object.values(response.data);
+        if (recvData.length === 4) {
+          useEffect(() => {
+            // eslint-disable-next-line max-len
+            store.dispatch(setLoggedUser({ nick: recvData[0], mail: recvData[1], img: recvData[3], status: recvData[2] } as LoggedUserData));
+          }, []);
+        }
+      } else if (response.status === 401) {
+        useEffect(() => {
+          store.dispatch(setAuth({ auth: false } as AuthData));
+        }, []);
+      }
+    });
+  }, []);
+}
+
+export { ReqLoggedUserDate };

--- a/src/redux/rootReducer.ts
+++ b/src/redux/rootReducer.ts
@@ -1,10 +1,12 @@
 import { combineReducers } from "@reduxjs/toolkit";
 import users from "./slices/users";
 import loggedUser from "./slices/loggedUser";
+import auth from "./slices/auth";
 
 const reducer = combineReducers({
   users,
-  loggedUser
+  loggedUser,
+  auth
 });
 
 export type ReducerType = ReturnType<typeof reducer>;

--- a/src/redux/slices/auth.ts
+++ b/src/redux/slices/auth.ts
@@ -1,0 +1,31 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+
+export interface AuthData {
+  auth: boolean;
+  auth2f: boolean;
+  isRequire2f: boolean;
+}
+
+export const auth = createSlice({
+  name: "auth",
+  initialState: {
+    auth: false, // Set true for test on local without auth.
+    auth2f: false,
+    isRequire2f: false
+  } as AuthData,
+  reducers: {
+    // eslint-disable-next-line no-return-assign
+    setAuth: (state, action: PayloadAction<AuthData>) => {
+      state.auth = action.payload.auth;
+    },
+    setAuth2f: (state, action: PayloadAction<AuthData>) => {
+      state.auth2f = action.payload.auth2f;
+    },
+    setAuthRequire2f: (state, action: PayloadAction<AuthData>) => {
+      state.isRequire2f = action.payload.isRequire2f;
+    },
+  }
+});
+
+export const { setAuth, setAuth2f, setAuthRequire2f } = auth.actions;
+export default auth.reducer;

--- a/src/redux/slices/loggedUser.ts
+++ b/src/redux/slices/loggedUser.ts
@@ -1,19 +1,19 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 
 export interface LoggedUserData {
-  id: number;
   nick: string;
+  mail: string;
   img: string;
-  status: number;
+  status: string;
 }
 
 export const loggedUser = createSlice({
   name: "loggedUser",
   initialState: {
-    id: 0,
     nick: "unknown",
+    mail: "unknown@unknown.com",
     img: "/asset/profileImage/skim.png",
-    status: 1
+    status: "USST10"
   } as LoggedUserData,
   reducers: {
     // eslint-disable-next-line no-return-assign

--- a/src/view/viewTemplate.tsx
+++ b/src/view/viewTemplate.tsx
@@ -1,6 +1,9 @@
 import React from "react";
 import { styled } from "@stitches/react";
-import * as theme from "../theme/theme";
+import { useSelector } from "react-redux";
+import { Navigate } from "react-router-dom";
+import { ReducerType } from "../redux/rootReducer";
+import { AuthData } from "../redux/slices/auth";
 
 import { ContainerNavMenu } from "../container/navMenu";
 import { ContainerNavCommunity } from "../container/navCommunity";
@@ -28,6 +31,12 @@ export const ViewWrapper = styled("div", {
 });
 
 export function ViewTemplate({ content } : any) {
+  const auth = useSelector<ReducerType, AuthData>((state) => state.auth);
+
+  if (!auth.auth || (auth.isRequire2f && !auth.auth2f)) {
+    return (<Navigate replace to="/login" />);
+  }
+
   return (
     <ViewWrapper className="view">
       <ContainerLeftBox>


### PR DESCRIPTION
## 수정 및 작업 내용
- login 페이지 url을 /(root)에서 /login 으로 변경.
- login 버튼 클릭시 이동하는 url 백엔드 변경에 맞춰 수정.
- /* 라우팅에 대해 컨트롤하는 rootControl 컴포넌트 추가. 인증에 따른 리다이렉션.
- auth redux slice 추가. 인증 제어 및 리다이렉션 개발 편의성 제공을 위함.
- nav 내 프로필에 대한 기능 구현.
- 수정한 파일들에 대한 eslint warning 제거.

## 사유
- 위 작업 내용에 대한 전반적인 CD 테스트 필요.
