### PR TITLE
fix: semi and no-extra-semi conflict

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,6 +14,8 @@
     },
     "plugins": ["react", "@typescript-eslint"],
     "rules": {
+      "no-extra-semi": "off",
+      "semi": "off",
       "quotes": ["error", "double"], //더블 쿼터 사용
       "@typescript-eslint/quotes": ["error", "double"], //더블 쿼터 사용
       "no-unused-vars": "off", //사용안한 변수 경고 중복


### PR DESCRIPTION
## 수정 및 작업 내용
- exlintrc.json 수정
  - "no-extra-semi": "off",
  - "semi": "off",

## 사유
- 세미콜론이 꼭 있어야 하는 규칙과 필요 없다고 판단되는 세미 콜론은 없어야 하는 규칙 간 충돌
