### PR TITLE
fix: Set chatRoomId to -1 when change content in contentChat.tsx

### DIFF
--- a/src/container/contentChat.tsx
+++ b/src/container/contentChat.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { styled } from "@stitches/react";
-import { useSelector } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
 import * as template from "./contentTemplate";
 import * as theme from "../theme/theme";
 import socketManager from "../feat/chat/socket";
@@ -9,7 +9,7 @@ import { FindRoom } from "../component/chat/chatFindRoom";
 import { ReducerType } from "../redux/rootReducer";
 import { JoinedChatRoomListData } from "../redux/slices/joinedChatRoomList";
 import { ComponentChatRoomListBox } from "../component/chat/chatRoomListBox";
-import { DisplayData } from "../redux/slices/display";
+import { DisplayData, setChatRoomId } from "../redux/slices/display";
 import { ComponentChatRoom } from "../component/chat/chatRoom";
 
 const TypeSelectSection = styled("div", {
@@ -140,6 +140,8 @@ export function ContainerContents() {
   // login for test
   const [userId, setUserId] = useState(-1);
   const [inputId, setInputId] = useState("");
+
+  const dispatch = useDispatch();
 
   useEffect(() => {
   }, [inputId]);
@@ -276,8 +278,8 @@ export function ContainerContents() {
         <MenuSection>
           <input style={{ width: "100px", height: "50px", marginRight: "15px", color: "white", backgroundColor: "black", fontSize: "30px" }} value={inputId} onChange={(event) => handleChange(event)} />
           <MenuButton onClick={() => login()}>login</MenuButton>
-          <MenuButton onClick={() => changeContent("create")}>create</MenuButton>
-          <MenuButton onClick={() => changeContent("find")}>find</MenuButton>
+          <MenuButton onClick={() => { changeContent("create"); dispatch(setChatRoomId({ chatRoomId: -1 } as DisplayData)); }}>create</MenuButton>
+          <MenuButton onClick={() => { changeContent("find"); dispatch(setChatRoomId({ chatRoomId: -1 } as DisplayData)); }}>find</MenuButton>
         </MenuSection>
       </template.DividedLeftSection>
       <template.DividedRightSection>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1922,9 +1922,9 @@
     "is-date-object" "^1.0.1"
     "is-symbol" "^1.0.2"
 
-"esbuild-linux-64@0.14.37":
-  "integrity" "sha512-UURL6k1Ffr6K4faFgdP6lKVvMKYwq8JmAh+odCukzIWN4EpjIzgmhBUzyFVU+VQLh1+K3tlE1SPJ057PNpayUQ=="
-  "resolved" "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.37.tgz"
+"esbuild-windows-64@0.14.37":
+  "integrity" "sha512-4mJjpS71AV4rj5PXrOn19uQwiASiyziJwyZT+qQ3M/hc/fIWS2Pgv5gbgytC1O8jptMB6NIpgrauCw56lKgckA=="
+  "resolved" "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.37.tgz"
   "version" "0.14.37"
 
 "esbuild@^0.14.27":


### PR DESCRIPTION
## 수정 및 작업 내용
- 채팅 메뉴에서 채팅 방 선택되어 있는 경우, Find 또는 Create 버튼 클릭 시 콘텐츠 변경 안 됨.
  채팅 방 선택 시, 해당 채팅 방 번호를 redux에서 저장하고 해당 방을 컨텐츠에 고정시킴.
  Find, Create 버튼 선택 시 이를 -1로 변경시켜줌.

## 사유
- bug