### PR TITLE
🚧 chat : design changed

### DIFF
--- a/src/component/chat/chatFindRoom.tsx
+++ b/src/component/chat/chatFindRoom.tsx
@@ -35,7 +35,7 @@ const ContentExitButton = styled("div", {
   cursor: "pointer",
 });
 
-const RoomListBox = styled("div", {
+const RoomListBox = styled(theme.NeonHoverRed, {
   display: "inline-block",
   justifyContent: "center",
   alignItems: "center",

--- a/src/component/chat/chatMessage.tsx
+++ b/src/component/chat/chatMessage.tsx
@@ -9,27 +9,30 @@ interface ChatMessageData {
 const Message = styled("div", {
   display: "flex",
   flexDirection: "row",
-  width: "90%",
+  width: "96%",
   height: "4rem",
   backgroundColor: "#252525",
   borderRadius: "1rem",
   fontSize: "1.5rem",
   margin: "0.5rem",
+  marginTop: "1.2rem",
+  marginBottom: "0rem",
 })
 
 const MessageSender = styled("div", {
   display: "flex",
   alignItems: "center",
   marginLeft: "1rem",
-  width: "25%",
+  width: "16%",
   fontWeight: "bold",
+  textOverflow: "ellipsis",
 })
 
 const MessageText = styled("div", {
   display: "flex",
   color: "white",
   alignItems: "center",
-  width: "75%",
+  width: "84%",
 
 })
 

--- a/src/component/chat/chatRoom.tsx
+++ b/src/component/chat/chatRoom.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+/* eslint-disable jsx-a11y/no-static-element-interactions */
 import React, { useState } from "react";
 import { styled } from "@stitches/react";
 import { useDispatch } from "react-redux";
@@ -40,10 +42,11 @@ const ChatRoomHeader = styled("div", {
   justifyContent: "space-between",
   width: "100%",
   height: "120px",
+  backgroundColor: "#000000",
 })
 
 const HeaderTitle = styled("p", {
-  marginLeft: "2rem",
+  marginRight: "2rem",
 })
 
 const HeaderInfo = styled("div", {
@@ -54,10 +57,11 @@ const HeaderInfo = styled("div", {
 
 const HeaderButton = styled("div", {
   fontSize: "1rem",
-  width: "2rem",
-  height: "2rem",
+  width: "1.3rem",
+  height: "1.3rem",
   margin: "0.5rem",
   cursor: "pointer",
+  marginTop: "-2rem",
   border: "1px solid #fff",
   textAlign: "center",
   verticalAlign: "middle",
@@ -115,30 +119,65 @@ export function ComponentChatRoom(props: any) {
 
   return (
     <ContentRoom>
-      <ContentExitButton onClick={() => { propFunc("empty"); dispatch(setChatRoomId({ chatRoomId: -1 } as DisplayData)); }}>X</ContentExitButton>
       <ChatRoomHeader>
-        <HeaderTitle>{chatRoomData.name}</HeaderTitle>
         <HeaderInfo>
-          <HeaderButton
+          <HeaderButton // room exit button
+            onClick={() => {
+              modal.SetModalSize("700px", "300px", "40%", "30%");
+              modal.SetModalContent(<div />);
+              dispatch(setModalTrigger({ ismodal: true } as DisplayData));
+            }}
+            style={{
+              border: "0",
+              backgroundColor: "#fd4546",
+              borderRadius: "100%",
+              marginLeft: "1.5rem",
+            }}
+          />
+          <HeaderButton // hide tab
+            onClick={() => {
+              propFunc("empty");
+              dispatch(setChatRoomId({ chatRoomId: -1 } as DisplayData));
+            }}
+            style={{
+              border: "0",
+              backgroundColor: "#fdaf24",
+              borderRadius: "100%",
+            }}
+          />
+          <HeaderButton // modal on : setting
             onClick={() => {
               modal.SetModalSize("900px", "900px", "7%", "24%");
               modal.SetModalContent(<div />);
               dispatch(setModalTrigger({ ismodal: true } as DisplayData));
             }}
-          >
-            L
-          </HeaderButton>
-          <HeaderButton
+            style={{
+              border: "0",
+              backgroundColor: "#28c231",
+              borderRadius: "100%",
+            }}
+          />
+          <HeaderButton // modal on : user list
             onClick={() => {
               modal.SetModalSize("900px", "900px", "7%", "24%");
               modal.SetModalContent(<div />);
               dispatch(setModalTrigger({ ismodal: true } as DisplayData));
             }}
+            style={{
+              background: "#FBFBEF",
+              borderRadius: "10px",
+              width: "5.7rem",
+              height: "1.3rem",
+              textAlign: "center",
+              verticalAlign: "middle",
+              fontSize: "1rem",
+              color: "black",
+            }}
           >
-            S
+            <b>00</b> joined
           </HeaderButton>
-          <HeaderButton>E</HeaderButton>
         </HeaderInfo>
+        <HeaderTitle>{chatRoomData.name}</HeaderTitle>
       </ChatRoomHeader>
       <ChatRoomRecvArea>
         <ChatMessage username="hyungyyo" message="sample message" />

--- a/src/container/contentChat.tsx
+++ b/src/container/contentChat.tsx
@@ -19,6 +19,7 @@ const TypeSelectSection = styled("div", {
   alignItems: "center",
   height: "10%",
   margin: "10px",
+  cursor: "pointer",
 });
 
 const RoomListSection = styled("div", {
@@ -47,7 +48,7 @@ const MenuSection = styled("div", {
   alignItems: "center",
 });
 
-const MenuButton = styled(theme.NeonHoverRed, {
+const MenuButton = styled("div", {
   display: "flex",
   justifyContent: "center",
   alignItems: "center",
@@ -58,7 +59,7 @@ const MenuButton = styled(theme.NeonHoverRed, {
   color: "grey",
 });
 
-const NeonBox = styled(theme.NeonHoverRed, {
+const NeonBox = styled("div", {
   width: "45%",
   height: "70%",
   borderRadius: "10px",
@@ -68,19 +69,27 @@ const NeonBox = styled(theme.NeonHoverRed, {
   display: "flex",
   justifyContent: "center",
   alignItems: "center",
+  transition: "all 1s",
   "&.clicked": {
     color: `${theme.NEON_RED}`,
     borderColor: `${theme.NEON_RED}`,
+    backgroundColor: "#2E2E2E",
   },
   "&.non-clicked": {
     color: "grey",
     borderColor: "grey",
   },
+  "&:hover": {
+    // border: `3px solid ${theme.NEON_RED}`,
+    color: `${theme.NEON_RED}`,
+    backgroundColor: "#1C1C1C",
+    filter: "drop-shadow(0 0 0px #000) brightness(1.6)",
+  },
 });
 
 // Content~ 컴포넌트는 렌더링 확인을 위한 샘플입니다.
 
-const ContentFind = styled(theme.NeonHoverRed, {
+const ContentFind = styled("div", {
   position: "relative",
   display: "flex",
   justifyContent: "center",
@@ -91,7 +100,7 @@ const ContentFind = styled(theme.NeonHoverRed, {
   height: "95%",
 });
 
-const ContentEmpty = styled(theme.NeonHoverRed, {
+const ContentEmpty = styled("div", {
   display: "flex",
   justifyContent: "center",
   alignItems: "center",
@@ -106,7 +115,7 @@ const ContentEmptyDiscription = styled("div", {
   fontSize: "20px",
 });
 
-const ContentExitButton = styled(theme.NeonHoverRed, {
+const ContentExitButton = styled("div", {
   position: "absolute",
   right: "20px",
   top: "20px",
@@ -199,11 +208,20 @@ export function ContainerContents() {
       if (listType === "chat") {
         if (joinedChatRoomList[i].type === "CHTP20" || joinedChatRoomList[i].type === "CHTP30" || joinedChatRoomList[i].type === "CHTP40") {
           renderList.push(
-            <ComponentChatRoomListBox
-              key={joinedChatRoomList[i].seq}
-              chatRoomData={joinedChatRoomList[i]}
-              stateUpdateFunc={setContentType}
-            />
+            <div>
+              <ComponentChatRoomListBox
+                key={joinedChatRoomList[i].seq}
+                chatRoomData={joinedChatRoomList[i]}
+                stateUpdateFunc={setContentType}
+              />
+              {/* <hr
+                key={joinedChatRoomList[i].seq}
+                style={{
+                  border: "1px dashed gray",
+                  width: "80%",
+                }}
+              /> */}
+            </div>
           );
         }
       } else if (joinedChatRoomList[i].type === "CHTP10") {
@@ -272,6 +290,7 @@ export function ContainerContents() {
         <TypeSelectSection>
           {renderTypeSelectButton()}
         </TypeSelectSection>
+        <hr style={{ border: "1px solid gray", width: "80%" }} />
         <RoomListSection>
           {renderJoinedRoomList()}
         </RoomListSection>

--- a/src/container/contentTemplate.tsx
+++ b/src/container/contentTemplate.tsx
@@ -34,29 +34,33 @@ export const DividedRightSection = styled(theme.NeonHoverRed, {
   height: `calc(${theme.NAV_LEFT_HEIGHT})`,
 });
 
-export const ListBox = styled(theme.NeonHoverRed, {
+export const ListBox = styled("div", {
   color: "grey",
   width: "90%",
   height: "100px",
   marginLeft: "1rem",
   marginRight: "1rem",
   marginBottom: "1rem",
+  transition: "all 1s",
   display: "flex",
   alignItems: "center",
   justifyContent: "center",
   cursor: "pointer",
   filter: "drop-shadow(0 0 0px gray)",
+  borderRadius: "10px",
   "&.clicked": {
     color: `${theme.NEON_RED}`,
     borderColor: `${theme.NEON_RED}`,
+    backgroundColor: "#2E2E2E",
   },
   "&.non-clicked": {
     color: "grey",
     borderColor: "grey",
   },
   "&:hover": {
-    border: `3px solid ${theme.NEON_RED}`,
+    // border: `3px solid ${theme.NEON_RED}`,
     color: `${theme.NEON_RED}`,
-    filter: `drop-shadow(0 0 0px ${theme.NEON_RED}) brightness(1.6)`,
+    backgroundColor: "#1C1C1C",
+    filter: "drop-shadow(0 0 0px #000) brightness(1.6)",
   },
 });


### PR DESCRIPTION
## 수정 및 작업 내용
- NeonHoverRed 효과가 너무 많아 디자인적으로 별로인 것 같은 부분을 대량 수정했습니다.
- Modal 버튼을 macOS의 창 control design을 적용하였으며, ChatRoomHeaderButton과 ChatRoomHeaderTitle을 변경하였습니다.
- Chat List? 에서의 디자인을 변경하였습니다. Hover 효과 중심으로 Hr이나 Border 없는 디자인을 적용하였습니다.

## 시안
<img width="422" alt="스크린샷 2022-07-14 오후 5 40 27" src="https://user-images.githubusercontent.com/35485904/178940877-ff08f3ee-7448-417b-9bac-67be4e75917d.png">
<img width="991" alt="스크린샷 2022-07-14 오후 5 41 05" src="https://user-images.githubusercontent.com/35485904/178940889-61aebad9-f49a-41f0-9e50-d2045a4fe830.png">
