### PR TITLE
🚧 #177 이름 길 경우 navAlarm에서 깨지는 문제 해결

### DIFF
--- a/src/component/nav/navAlam.tsx
+++ b/src/component/nav/navAlam.tsx
@@ -18,7 +18,12 @@ import socketManager from "../../network/api/socket";
 const ProfileTextName = styled("div", {
   width: "100%",
   height: "auto",
+  marginTop: "5px",
   fontSize: "2.5rem",
+  textOverflow: "ellipsis",
+  overflow: "hidden",
+  whiteSpace: "nowrap",
+  display: "block",
   color: "Orange",
 });
 


### PR DESCRIPTION
## 수정 및 작업 내용
- #177 이슈 확인하시면 될 것 같습니다.
- font-size와 marginTop 설정하였습니다.
- <a href="https://junistory.blogspot.com/2017/06/css-ellipsis.html">이 블로그</a> 보고 해결하였습니다.
```
textOverflow: "ellipsis",
overflow: "hidden",
whiteSpace: "nowrap",
display: "block",
```