### PR TITLE
:sparkles: user search list에 modal 붙이고 friend랑 같은 interface 보도록 했습니다

### DIFF
--- a/src/component/modal/modalNavFriendBox.tsx
+++ b/src/component/modal/modalNavFriendBox.tsx
@@ -281,7 +281,7 @@ function isNumber(str: any): boolean {
 
 export function ModalNavFriendBox(props: any) {
   const { user } = props;
-  console.log("user props : ", user);
+
   const [content, setContent] = useState<JSX.Element>(
     <div>
       <b>로딩중입니다.</b>

--- a/src/component/nav/navAlam.tsx
+++ b/src/component/nav/navAlam.tsx
@@ -14,7 +14,7 @@ import { ComponentNavAlamBox } from "./navAlamBox";
 import socketManager from "../../network/api/socket";
 
 const ProfileTextName = styled("div", {
-  width: "90%",
+  width: "95%",
   height: "auto",
   marginTop: "10px",
   fontSize: "1.8rem",
@@ -232,14 +232,6 @@ export function ComponentNavAlam() {
         <NavNotificationButton
           src="/asset/notification_icon.png"
           onClick={handleAlarmOpen}
-          //   modal.SetModalContent(
-          //     <div>
-          //       <NavAlarmList>
-          //         {renderAlarmList()}
-          //       </NavAlarmList>
-          //     </div>
-          //   );
-          // }}
         />
       </NavAlarmAlarm>
     </NavAlarm>

--- a/src/component/nav/navFriendBox.tsx
+++ b/src/component/nav/navFriendBox.tsx
@@ -14,9 +14,9 @@ export function ComponentNavFriendBox(props: any) {
     if (status === "in game") return ("yellow");
     return ("red");
   };
-  const { friend } = props;
+  const { user } = props;
 
-  const statusColor:string = setStatusColor(StatusDisplayDistributor(friend.status));
+  const statusColor:string = setStatusColor(StatusDisplayDistributor(user.status));
 
   const style = theme.modalStyle;
   style.top = "40%";
@@ -32,23 +32,20 @@ export function ComponentNavFriendBox(props: any) {
       <Modal
         open={open}
         onClose={handleClose}
-        aria-labelledby="modal-modal-title"
-        aria-describedby="modal-modal-description"
       >
         <Box sx={style} component="div">
-          <div>"heelo world"</div>
-          {/* <ModalNavFriendBox user={friend} /> */}
+          <ModalNavFriendBox user={user} />
         </Box>
       </Modal>
       <template.ProfileImage
-        src={`${window.location.origin}${friend.img}`}
+        src={`${window.location.origin}${user.img}`}
         className="profile"
         onClick={handleOpen}
       />
       <template.Profile>
-        <template.ProfileName> {friend.nick} </template.ProfileName>
+        <template.ProfileName> {user.nick} </template.ProfileName>
         <template.StatusMessage style={{ color: statusColor }}>
-          {StatusDisplayDistributor(friend.status)}
+          {StatusDisplayDistributor(user.status)}
         </template.StatusMessage>
       </template.Profile>
     </template.NavBox>

--- a/src/component/nav/navFriendZone.tsx
+++ b/src/component/nav/navFriendZone.tsx
@@ -98,7 +98,7 @@ export function ComponentNavFriendZone() {
       }
       for (let i = 0; i < friendList.length; i += 1) {
         renderResult.push(
-          <ComponentNavFriendBox key={i} friend={friendList[i]} />
+          <ComponentNavFriendBox key={i} user={friendList[i]} />
         );
       }
     }

--- a/src/component/nav/navSearchResultBox.tsx
+++ b/src/component/nav/navSearchResultBox.tsx
@@ -1,8 +1,11 @@
-import React from "react";
+import React, { useState } from "react";
 import { styled } from "@stitches/react";
+import Box from "@mui/material/Box";
+import Modal from "@mui/material/Modal";
 import * as theme from "../../theme/theme";
 import * as template from "./navBoxTemplate";
 import { StatusDisplayDistributor } from "../../feat/profile/utils";
+import { FriendData } from "../../redux/slices/friendList";
 import { ModalNavFriendBox } from "../modal/modalNavFriendBox";
 
 export function ComponentNavSearchUserBox(props: any) {
@@ -14,20 +17,48 @@ export function ComponentNavSearchUserBox(props: any) {
   };
 
   const { searchUser } = props;
+  const user:FriendData = {
+    seq: searchUser.userSeq,
+    nick: searchUser.nickName,
+    img: searchUser.userImage,
+    status: searchUser.userStatus,
+  };
 
-  const statusColor:string = setStatusColor(StatusDisplayDistributor(searchUser.userStatus));
+  const style = theme.modalStyle;
+  style.top = "40%";
+  style.width = "300px";
+  style.height = "auto";
+  style.left = "calc(100% - 450px)";
+  const [open, setOpen] = useState(false);
+  const handleOpen = () => setOpen(true);
+  const handleClose = () => setOpen(false);
+
+  const statusColor:string = setStatusColor(StatusDisplayDistributor(user.status));
   return (
-    <template.NavBox>
-      <template.ProfileImage
-        src={`${window.location.origin}${searchUser.userImage}`}
-        className="profile"
-      />
-      <template.Profile>
-        <template.ProfileName> {searchUser.nickName} </template.ProfileName>
-        <template.StatusMessage style={{ color: statusColor }}>
-          {StatusDisplayDistributor(searchUser.userStatus)}
-        </template.StatusMessage>
-      </template.Profile>
-    </template.NavBox>
+    <div>
+      <Modal
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="modal-modal-title"
+        aria-describedby="modal-modal-description"
+      >
+        <Box sx={style} component="div">
+          <ModalNavFriendBox user={user} />
+        </Box>
+      </Modal>
+      <template.NavBox onClick={handleOpen}>
+
+        <template.ProfileImage
+          src={`${window.location.origin}${user.img}`}
+          className="profile"
+        />
+        <template.Profile>
+          <template.ProfileName> {user.nick} </template.ProfileName>
+          <template.StatusMessage style={{ color: statusColor, width: "100%", }}>
+            {StatusDisplayDistributor(user.status)}
+          </template.StatusMessage>
+        </template.Profile>
+      </template.NavBox>
+    </div>
   );
 }


### PR DESCRIPTION
## 수정 및 작업 내용
- Search List와 Friend List에서 참조하는 interface?에서 변수명(seq vs userSeq 등)이 달라서 같은 걸 불러쓰도록 통일했습니다
- friend는 더미데이터가 없어서 확인을 아직 못했지만 userList에서 modal 작동하도록 하였습니다
- 영어 이름과 달리 한글 이름에서 status가 왼쪽으로 붙어있지 않았던 현상을 width: 100%를 줘서 해결하였습니다
