### PR TITLE
:hammer: Nav friend modal improved.

### DIFF
--- a/src/component/modal/modalNavFriendBox.tsx
+++ b/src/component/modal/modalNavFriendBox.tsx
@@ -222,9 +222,9 @@ export function ModalNavFriendBox(props: any) {
     window.location.href = link;
   }
 
-  function buttonClickAxios() {
-
-  }
+  const [gameButtonToggle, setGameButtonToggle] = useState(0);
+  const [friendButtonToggle, setFriendButtonToggle] = useState(0);
+  const [blockButtonToggle, setBlockButtonToggle] = useState(0);
 
   useEffect(() => {
     let searchSeq: any = "-1";
@@ -248,7 +248,10 @@ export function ModalNavFriendBox(props: any) {
         } else {
           defineList.push({
             name: "DM",
-            onClick: () => { postNewDM(userInfo.user_info.userSeq) },
+            onClick: () => {
+              postNewDM(userInfo.user_info.userSeq);
+              buttonClickHref("/chat");
+            },
             disabled: false,
           });
           let bFriend: boolean = false;
@@ -258,42 +261,103 @@ export function ModalNavFriendBox(props: any) {
               break;
             }
           }
-          if (bFriend) {
+          if (friendButtonToggle === 0) {
+            if (bFriend) {
+              defineList.push({
+                name: "delete friend",
+                onClick: () => {
+                  postFriendDelete(userInfo.user_info.userSeq);
+                  setFriendButtonToggle(1);
+                },
+                disabled: false,
+              });
+            } else {
+              defineList.push({
+                name: "add friend",
+                onClick: () => {
+                  postFriendRequest(userInfo.user_info.userSeq);
+                  setFriendButtonToggle(1);
+                },
+                disabled: false,
+              });
+            }
+          } else if (friendButtonToggle === 1) {
+            if (bFriend) {
+              defineList.push({
+                name: "delete friend complete",
+                onClick: () => {},
+                disabled: true,
+              });
+            } else {
+              defineList.push({
+                name: "friend request ongoing...",
+                onClick: () => {},
+                disabled: true,
+              });
+            }
+          }
+          if (blockButtonToggle === 0) {
+            if (userInfo.relation_info === "R03") {
+              defineList.push({
+                name: "unblock",
+                onClick: () => {
+                  requestUserUnblock(userInfo.user_info.userSeq);
+                  setBlockButtonToggle(1);
+                },
+                disabled: false,
+              });
+            } else {
+              defineList.push({
+                name: "block",
+                onClick: () => {
+                  requestUserBlock(userInfo.user_info.userSeq);
+                  setBlockButtonToggle(1);
+                },
+                disabled: false,
+              });
+            }
+          } else if (blockButtonToggle === 1) {
+            if (userInfo.relation_info === "R03") {
+              defineList.push({
+                name: "unblock complete",
+                onClick: () => {},
+                disabled: true,
+              });
+            } else {
+              defineList.push({
+                name: "block complete",
+                onClick: () => {},
+                disabled: true,
+              });
+            }
+          }
+          if (gameButtonToggle === 0) {
+            if (userInfo.user_info.userStatus === "USST10") {
+              defineList.push({
+                name: "game",
+                onClick: () => {
+                  postGameInvite(userInfo.user_info.userSeq);
+                  setGameButtonToggle(1);
+                },
+                disabled: false,
+              });
+            }
+          } else if (gameButtonToggle === 1) {
+            if (userInfo.user_info.userStatus === "USST10") {
+              defineList.push({
+                name: "game request ongoing...",
+                onClick: () => {},
+                disabled: true,
+              });
+            }
+          }
+          if (userInfo.user_info.userStatus === "USST30") {
             defineList.push({
-              name: "delete friend",
-              onClick: () => { postFriendDelete(userInfo.user_info.userSeq) },
-              disabled: false,
-            });
-          } else {
-            defineList.push({
-              name: "add friend",
-              onClick: () => { postFriendRequest(userInfo.user_info.userSeq) },
+              name: "watch",
+              onClick: () => { buttonClickHref("/watch"); },
               disabled: false,
             });
           }
-          if (userInfo.relation_info === "R03") {
-            defineList.push({
-              name: "unblock",
-              onClick: () => { requestUserUnblock(userInfo.user_info.userSeq) },
-              disabled: false,
-            });
-          } else {
-            defineList.push({
-              name: "block",
-              onClick: () => { requestUserBlock(userInfo.user_info.userSeq) },
-              disabled: false,
-            });
-          }
-          defineList.push({
-            name: "game",
-            onClick: () => { postGameInvite(userInfo.user_info.userSeq) },
-            disabled: false,
-          });
-          defineList.push({
-            name: "watch",
-            onClick: () => { buttonClickHref("/watch"); },
-            disabled: false,
-          });
         }
 
         const realContent: JSX.Element[] = []
@@ -310,7 +374,7 @@ export function ModalNavFriendBox(props: any) {
         <b style={{ color: "red" }}>An error occurred. {error}</b>
       );
     });
-  }, []);
+  }, [friendButtonToggle, gameButtonToggle, blockButtonToggle]);
 
   return (
     <ModalContentDiv>

--- a/src/component/modal/modalNavFriendBox.tsx
+++ b/src/component/modal/modalNavFriendBox.tsx
@@ -361,9 +361,9 @@ export function ModalNavFriendBox(props: any) {
         }
 
         const realContent: JSX.Element[] = []
-        realContent.push(<Profile response={userInfo} />);
-        if (userInfo.user_info.isFriend === true) realContent.push(<Status status={user.status} />)
-        realContent.push(<Buttons render={defineList} />);
+        realContent.push(<Profile key={0} response={userInfo} />);
+        realContent.push(<Status key={1} status={user.status} />)
+        realContent.push(<Buttons key={2} render={defineList} />);
 
         setContent(
           <>{ realContent }</>

--- a/src/component/nav/navFriendZone.tsx
+++ b/src/component/nav/navFriendZone.tsx
@@ -79,13 +79,13 @@ export function ComponentNavFriendZone() {
         })
       } else {
         const res: any = searchResult;
-        if (res?.data.length === 0 || res?.status !== 200) {
+        if (res?.data?.length === 0 || res?.status !== 200) {
           renderResult.push(
             <EmptyFriend key={0}>No search results</EmptyFriend>
           );
         } else {
-          for (let i = 0; i < res?.data.length; i += 1) {
-            if (loggedUser.nick !== res?.data[i].nickName) {
+          for (let i = 0; i < res?.data?.length; i += 1) {
+            if (loggedUser.nick !== res?.data[i]?.nickName) {
               renderResult.push(
                 <ComponentNavSearchUserBox key={i} searchUser={res?.data[i]} />
               );


### PR DESCRIPTION
## 수정 및 작업 내용
- nav user 모달 버튼 편의성 개선.
  - 요청 버튼(친추, 친삭, 블락, 게임) 클릭시 반응 추가.
  - 리다이렉트 필요 버튼(DM, 관전) 클릭시 해당 페이지로 이동(해당 기능의 페이지로 이동만 할 뿐 해당 채팅방, 관전방으로 가진 못함. 구현 위해선 API 개선이 필요. 구지 이거까지 할 필요는 없다고 생각중).
  - 모달 대상 유저 상태에 따라 버튼 목록 분기 추가(game, watch).

## 사유
- 기능 개선.
